### PR TITLE
Create jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Describe your changes

This pull request introduces a new GitHub Actions workflow for building and deploying a Jekyll site to GitHub Pages. The workflow is designed to run on pushes to the main branch and can also be triggered manually. It includes steps for building the site and deploying it to GitHub Pages.

Key changes:

* Added a new workflow file `.github/workflows/jekyll-gh-pages.yml` to automate the building and deployment of a Jekyll site to GitHub Pages.
* Configured the workflow to run on pushes to the `main` branch and manual triggers via the Actions tab.
* Set permissions for the `GITHUB_TOKEN` to allow reading contents and writing pages and id-token.
* Defined a build job that checks out the repository, sets up GitHub Pages, builds the site with Jekyll, and uploads the build artifact.
* Defined a deployment job that runs after the build job, deploying the site to GitHub Pages and providing the deployment URL.

